### PR TITLE
remove MAGICL/EXT from MAGICL/CORE

### DIFF
--- a/magicl.asd
+++ b/magicl.asd
@@ -13,6 +13,7 @@
   :version (:read-file-form "VERSION.txt")
   :in-order-to ((asdf:test-op (asdf:test-op #:magicl-tests)))
   :depends-on (#:magicl/core
+               #:magicl/ext
                #:magicl/ext-blas
                #:magicl/ext-lapack
                #:magicl/ext-expokit))
@@ -27,8 +28,6 @@
                #:abstract-classes
                #:policy-cond
                #:interface              ; for CALLING-FORM
-
-               #:magicl/ext             ; Allow extensions
                )
   :around-compile (lambda (compile)
                     (let (#+sbcl (sb-ext:*derive-function-types* t))
@@ -62,7 +61,8 @@
 
 (asdf:defsystem #:magicl/ext
   :description "Common code for extending MAGICL with foreign libraries."
-  :depends-on (#:cffi
+  :depends-on (#:magicl/core
+               #:cffi
                #:cffi-libffi)
   :serial t
   :pathname "src/extensions/common"
@@ -70,7 +70,8 @@
   ((:file "package")
    (:file "library-tracking")
    (:file "with-array-pointers")
-   (:file "cffi-types")))
+   (:file "cffi-types")
+   (:file "ptr-ref")))
 
 ;;; BLAS
 

--- a/src/extensions/common/package.lisp
+++ b/src/extensions/common/package.lisp
@@ -3,6 +3,7 @@
         #:cffi)
   (:export #+sbcl #:array-pointer       ; FUNCTION
            #:with-array-pointers        ; MACRO
+           #:ptr-ref                    ; GENERIC, METHOD
            #:complex-single-float
            #:complex-double-float
            #:fortran-int

--- a/src/extensions/common/ptr-ref.lisp
+++ b/src/extensions/common/ptr-ref.lisp
@@ -1,0 +1,21 @@
+(in-package #:magicl.cffi-types)
+
+;; TODO: This should be generic to abstract-tensor
+(defgeneric ptr-ref (m base i j)
+  (:documentation
+   "Accessor method for the pointer to the element in the I-th row and J-th column of a matrix M, assuming zero indexing.")
+  (:method ((m magicl:matrix) base i j)
+    (policy-cond:with-expectations (> speed safety)
+        ((assertion (magicl:valid-index-p (list i j) (magicl:shape m))))
+      (let ((type (magicl:element-type m)))
+        (let ((idx (apply (ecase (magicl:layout m)
+                            (:column-major #'magicl:matrix-column-major-index)
+                            (:row-major #'magicl:matrix-row-major-index))
+                          i j (magicl:shape m))))
+          (cond
+            ((subtypep type 'single-float) (cffi:mem-aptr base :float idx))
+            ((subtypep type 'double-float) (cffi:mem-aptr base :double idx))
+            ((subtypep type '(complex single-float)) (cffi:mem-aptr base :float (* 2 idx)))
+            ((subtypep type '(complex double-float)) (cffi:mem-aptr base :double (* 2 idx)))
+            (t (error "Incompatible element type ~a." type))))))))
+

--- a/src/extensions/lapack/lapack-csd.lisp
+++ b/src/extensions/lapack/lapack-csd.lisp
@@ -131,9 +131,9 @@
       ;; HOURS WASTED HERE: 10
       (magicl.cffi-types:with-array-pointers ((xcopy-ptr (magicl::storage xcopy)))
         (let ((x11 xcopy-ptr)
-              (x12 (magicl::ptr-ref xcopy xcopy-ptr 0 q))
-              (x21 (magicl::ptr-ref xcopy xcopy-ptr p 0))
-              (x22 (magicl::ptr-ref xcopy xcopy-ptr p q))
+              (x12 (magicl.cffi-types:ptr-ref xcopy xcopy-ptr 0 q))
+              (x21 (magicl.cffi-types:ptr-ref xcopy xcopy-ptr p 0))
+              (x22 (magicl.cffi-types:ptr-ref xcopy xcopy-ptr p q))
               (theta (make-array r
                                  :element-type 'double-float))
               (u1 (make-array (* ldu1 p)

--- a/src/high-level/matrix.lisp
+++ b/src/high-level/matrix.lisp
@@ -258,25 +258,6 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
           (setf d (cl:map 'list (lambda (di) (/ di (sqrt (* di (conjugate di))))) d))
           (@ q (funcall #'from-diag d)))))))
 
-;; TODO: This should be generic to abstract-tensor
-(defgeneric ptr-ref (m base i j)
-  (:documentation
-   "Accessor method for the pointer to the element in the I-th row and J-th column of a matrix M, assuming zero indexing.")
-  (:method ((m matrix) base i j)
-    (policy-cond:with-expectations (> speed safety)
-        ((assertion (valid-index-p (list i j) (shape m))))
-      (let ((type (element-type m)))
-        (let ((idx (apply (ecase (layout m)
-                            (:column-major #'matrix-column-major-index)
-                            (:row-major #'matrix-row-major-index))
-                          i j (shape m))))
-          (cond
-            ((subtypep type 'single-float) (cffi:mem-aptr base :float idx))
-            ((subtypep type 'double-float) (cffi:mem-aptr base :double idx))
-            ((subtypep type '(complex single-float)) (cffi:mem-aptr base :float (* 2 idx)))
-            ((subtypep type '(complex double-float)) (cffi:mem-aptr base :double (* 2 idx)))
-            (t (error "Incompatible element type ~a." type))))))))
-
 (defgeneric row (matrix index)
   (:documentation "Get row vector from a matrix")
   (:method ((m matrix) index)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -29,10 +29,6 @@
            #:notevery
            #:notany)
 
-  (:import-from #:magicl.foreign-libraries
-                #:print-availability-report)
-  (:export #:print-availability-report)
-
   (:import-from #:magicl.backends
                 #:no-applicable-implementation
                 #:define-compatible-no-applicable-method-behavior
@@ -180,4 +176,11 @@
 
            ;; Vector operators
            #:dot
-           #:norm))
+           #:norm
+
+           ;; Misc utilities
+           #:row-major-index
+           #:matrix-row-major-index
+           #:column-major-index
+           #:matrix-column-major-index
+           #:valid-index-p))


### PR DESCRIPTION
This eliminates CFFI and CFFI-LIBFFI as dependencies, making
MAGICL easier to load on platforms without a C compiler.