### PR TITLE
support Allegro CL 10.1

### DIFF
--- a/src/extensions/common/with-array-pointers.lisp
+++ b/src/extensions/common/with-array-pointers.lisp
@@ -32,7 +32,7 @@ WARNING: Do not close over these pointers or otherwise store them outside of the
                  bindings)
           (bindings)
           "Malformed bindings in WITH-ARRAY-POINTERS. Given ~S" bindings)
-  #- (or sbcl ccl ecl)
+  #- (or sbcl ccl ecl allegro)
   (error "WITH-ARRAY-POINTERS unsupported on ~A" (lisp-implementation-type))
 
   (let* ((symbols (mapcar #'first bindings))
@@ -84,4 +84,7 @@ WARNING: Do not close over these pointers or otherwise store them outside of the
              (let ,(loop :for s :in symbols
                          :for e :in evaled-symbols
                          :collect `(,s (si:make-foreign-data-from-array ,e)))
-               ,@body))))))
+               ,@body))
+           #+allegro
+           (let ,(mapcar #'list symbols evaled-symbols)
+             ,@body)))))

--- a/src/extensions/lapack/lapack-csd.lisp
+++ b/src/extensions/lapack/lapack-csd.lisp
@@ -74,10 +74,10 @@
 
     (let ((v2h (conjugate (/ 1.0d0 (- (* c (conjugate u2) a4)
                                       (* s (conjugate u1) a3)))))
-          (mu1 (empty '(1 1)))
-          (mu2 (empty '(1 1)))
-          (mv1h (empty '(1 1)))
-          (mv2h (empty '(1 1))))
+          (mu1 (empty '(1 1) :type '(complex double-float)))
+          (mu2 (empty '(1 1) :type '(complex double-float)))
+          (mv1h (empty '(1 1) :type '(complex double-float)))
+          (mv2h (empty '(1 1) :type '(complex double-float))))
 
       (macrolet ((matrix-1x1-data (matrix)
                    `(the (simple-array (complex double-float) (1)) (magicl::storage ,matrix))))
@@ -130,6 +130,7 @@
       ;;
       ;; HOURS WASTED HERE: 10
       (magicl.cffi-types:with-array-pointers ((xcopy-ptr (magicl::storage xcopy)))
+        #+allegro (setq xcopy-ptr (ff:fslot-address-typed :unsigned-char :lisp (magicl::storage xcopy)))
         (let ((x11 xcopy-ptr)
               (x12 (magicl.cffi-types:ptr-ref xcopy xcopy-ptr 0 q))
               (x21 (magicl.cffi-types:ptr-ref xcopy xcopy-ptr p 0))

--- a/src/high-level/tensor.lisp
+++ b/src/high-level/tensor.lisp
@@ -46,6 +46,7 @@ COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
                          (:copier ,copy-sym))
          (storage nil :type (tensor-storage ,type)))
        #+sbcl (declaim (sb-ext:freeze-type ,name))
+       #+allegro (set-pprint-dispatch ',name 'pprint-tensor)
        
        (defmethod storage ((m ,name))
          (,storage-sym m))
@@ -68,9 +69,8 @@ COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
                        (apply #'make-array
                               size
                               :element-type ',type
-                              (if initial-element
-                                  (list :initial-element (coerce initial-element ',type))
-                                  nil)))))))
+                              (list :initial-element (coerce (if initial-element initial-element 0) ',type))))))))
+
        (defmethod cast ((tensor ,name) (class (eql ',name)))
          (declare (ignore class))
          tensor)

--- a/src/high-level/vector.lisp
+++ b/src/high-level/vector.lisp
@@ -33,6 +33,7 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
                          (:copier ,copy-sym))
          (storage nil :type (vector-storage ,type)))
        #+sbcl (declaim (sb-ext:freeze-type ,name))
+       #+allegro (set-pprint-dispatch ',name 'pprint-vector)
 
        (defmethod storage ((v ,name))
          (,storage-sym v))
@@ -54,9 +55,7 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
                        (apply #'make-array
                               size
                               :element-type ',type
-                              (if initial-element
-                                  (list :initial-element (coerce initial-element ',type))
-                                  nil)))))))
+                              (list :initial-element (coerce (if initial-element initial-element 0) ',type))))))))
 
        (defmethod cast ((tensor ,name) (class (eql ',name)))
          (declare (ignore class))


### PR DESCRIPTION
This PR provides support for Allegro CL 10.1 (modern cased `mlisp` not supported).

All tests passed for both Allegro and SBCL in a Linux 64bit environment.

Some interesting changes are:

* _storage_ constructors will explicitly use **0** as the initial elements;
the reason is if `:initial-element` is not supplied in `make-array`,
then the behaviour is not defined
* allegro-specific implementation added for the `with-array-pointer`
macro
* pretty printers explicitly dispatched in the `deftensor`, `defvector`
and `defmatrix` macros
* an allegro-specific fix for `lapack-csd` method added