### PR TITLE
Add lisp & static-vectors allocators for tensor storage

### DIFF
--- a/magicl-tests.asd
+++ b/magicl-tests.asd
@@ -10,7 +10,8 @@
                #:uiop
                #:magicl
                #:magicl-examples
-               #:fiasco)
+               #:fiasco
+               #:trivial-garbage)
   :perform (asdf:test-op (o s)
                          (uiop:symbol-call :magicl-tests
                                            '#:run-magicl-tests))
@@ -20,6 +21,7 @@
                (:file "suite")
                (:file "constants")
                (:file "util-tests")
+               (:file "allocation-tests")
                (:file "abstract-tensor-tests")
                (:file "specialization-tests")
                (:file "constructor-tests")

--- a/magicl.asd
+++ b/magicl.asd
@@ -28,6 +28,8 @@
                #:abstract-classes
                #:policy-cond
                #:interface              ; for CALLING-FORM
+               #:static-vectors
+               #:trivial-garbage
                )
   :around-compile (lambda (compile)
                     (let (#+sbcl (sb-ext:*derive-function-types* t))
@@ -41,6 +43,7 @@
    (:module "high-level"
     :serial t
     :components ((:file "util")
+                 (:file "allocation")
                  (:file "shape")
                  (:file "abstract-tensor")
                  (:file "specialize-tensor")

--- a/src/high-level/allocation.lisp
+++ b/src/high-level/allocation.lisp
@@ -1,0 +1,67 @@
+;;; allocation.lisp
+;;;
+;;; Control allocation of tensors. Derived from QVM's allocator.lisp
+;;; 
+;;; Author: Erik Davis
+
+(in-package #:magicl)
+
+
+(deftype finalizer ()
+  "A finalizer thunk. Used for the effect of freeing some memory."
+  '(function () null))
+
+(defun dummy-finalizer ()
+  "A \"finalizer\" that does nothing. Used for objects managed by the GC."
+  nil)
+
+(deftype allocator ()
+  "A routine to allocate storage for a fresh tensor with an indicated number of elements of type ELEMENT-TYPE, with entries defaulting to INITIAL-ELEMENT. Return two values:
+    1. The allocated storage.
+    2. A finalizer thunk of type FINALIZER, which should be called when the memory is OK to be freed.
+NOTE: Note that the finalizer may close over the allocated vector."
+  '(function (integer &key (:element-type t) (:initial-element t)) (values (simple-array *) finalizer)))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;; Lisp Heap Allocation ;;;;;;;;;;;;;;;;;;;;;;;;
+
+(declaim (ftype allocator lisp-allocator))
+(defun lisp-allocator (size &key element-type initial-element)
+  (let ((storage
+          (apply #'make-array
+                 size
+                 :element-type element-type
+                 (if initial-element
+                     (list ':initial-element (coerce initial-element element-type))
+                     nil))))
+    (values storage
+            #'dummy-finalizer)))
+
+
+;;;;;;;;;;;;;;;;;;;;; Foreign Memory Allocation ;;;;;;;;;;;;;;;;;;;;;;
+
+(declaim (ftype allocator c-allocator))
+(defun c-allocator (size &key element-type initial-element)
+  (let ((storage
+          (apply #'static-vectors:make-static-vector
+                 size
+                 :element-type element-type
+                 (if initial-element
+                     (list ':initial-element (coerce initial-element element-type))
+                     nil))))
+    (values storage
+            (lambda ()
+              (static-vectors:free-static-vector storage)))))
+
+
+;;;;;;;;;;;;;;;;;;;;; Default Allocation Settings ;;;;;;;;;;;;;;;;;;;;;;
+
+(declaim (type allocator *default-allocator*))
+(defvar *default-allocator* #'lisp-allocator
+  "The default allocation to use for tensor storage. ")
+
+(defun allocate (size &key element-type initial-element)
+  "Allocate storage for a fresh tensor."
+  (funcall *default-allocator* size
+           :element-type element-type
+           :initial-element initial-element))

--- a/src/high-level/constructors.lisp
+++ b/src/high-level/constructors.lisp
@@ -81,7 +81,7 @@ If OFFSET is specified then the diagonal band will be offset by that much, posit
        ;; NOTE: We infer the tensor type this late to allow for
        ;; reassignment of SHAPE in the assertion.
        (let* ((tensor-class (infer-tensor-type type shape value))
-              (tensor (make-tensor tensor-class shape :layout layout))
+              (tensor (make-tensor tensor-class shape :layout layout :initial-element 0))
               (fill-value (coerce (or value 1) (element-type tensor)))) ;; TODO: use registry)
          (loop :for i :from (max 0 (- offset)) :below (first shape)
                :for j :from (max 0 offset) :below (second shape) :do
@@ -89,7 +89,7 @@ If OFFSET is specified then the diagonal band will be offset by that much, posit
          tensor))
       (t
        (let* ((tensor-class (infer-tensor-type type shape value))
-              (tensor (make-tensor tensor-class shape :layout layout))
+              (tensor (make-tensor tensor-class shape :layout layout :initial-element 0))
               (fill-value (coerce (or value 1) (element-type tensor))) ;; TODO: use registry
               (shape-length (length shape)))
          (dotimes (i (reduce #'min shape) tensor)
@@ -196,7 +196,7 @@ If OFFSET is specified then the diagonal band will be offset by that much, posit
      (let* ((length (+ (length list) (abs offset)))
             (shape (fixnum-to-shape length order))
             (tensor-class (infer-tensor-type type shape (first list)))
-            (tensor (make-tensor tensor-class shape :layout layout)))
+            (tensor (make-tensor tensor-class shape :layout layout :initial-element 0)))
        (loop :for i :from (max 0 (- offset)) :below (first shape)
              :for j :from (max 0 offset) :below (second shape) :do
                (setf (tref tensor i j) (pop list)))
@@ -205,7 +205,7 @@ If OFFSET is specified then the diagonal band will be offset by that much, posit
      (let* ((length (+ (length list) (abs offset)))
             (shape (fixnum-to-shape length order))
             (tensor-class (infer-tensor-type type shape (first list)))
-            (tensor (make-tensor tensor-class shape :layout layout)))
+            (tensor (make-tensor tensor-class shape :layout layout :initial-element 0)))
        (dotimes (i (reduce #'min shape) tensor)
          (setf (apply #'tref tensor (make-list order :initial-element i))
                (pop list)))))))

--- a/src/high-level/einsum.lisp
+++ b/src/high-level/einsum.lisp
@@ -187,7 +187,7 @@ suit different needs (e.g., LPARALLEL:PDOTIMES.)
                              ,expr))))
            (let-result-array (expr)
              "Evaluate EXPR and return the result erray."
-             `(let ((,result-array ,(or output-array `(make-array (list ,@output-dims) :initial-element 0.0))))
+             `(let ((,result-array ,(or output-array `(rray (list ,@output-dims) :initial-element 0.0))))
                 ,expr
                 ,result-array)))
       

--- a/src/high-level/einsum.lisp
+++ b/src/high-level/einsum.lisp
@@ -187,7 +187,7 @@ suit different needs (e.g., LPARALLEL:PDOTIMES.)
                              ,expr))))
            (let-result-array (expr)
              "Evaluate EXPR and return the result erray."
-             `(let ((,result-array ,(or output-array `(rray (list ,@output-dims) :initial-element 0.0))))
+             `(let ((,result-array ,(or output-array `(make-array (list ,@output-dims) :initial-element 0.0))))
                 ,expr
                 ,result-array)))
       

--- a/src/high-level/matrix.lisp
+++ b/src/high-level/matrix.lisp
@@ -474,7 +474,7 @@ If :SQUARE is T, then the result will be restricted to the upper rightmost squar
           (n (ncols matrix)))
       (let* ((end-i (if square (min m n) m))
              (start-j (if square (- n end-i) 0))
-             (target (empty (list end-i (- n start-j))
+             (target (zeros (list end-i (- n start-j))
                             :layout (layout matrix) :type (element-type matrix))))
         (loop :for i :below end-i
               :do (loop :for j :from (+ start-j i) :below n
@@ -494,7 +494,7 @@ If :SQUARE is T, then the result will be restricted to the lower leftmost square
           (n (ncols matrix)))
       (let* ((end-j (if square (min m n) n))
              (start-i (if square (- m end-j) 0))
-             (target (empty (list (- m start-i) end-j)
+             (target (zeros (list (- m start-i) end-j)
                             :layout (layout matrix) :type (element-type matrix))))
         (loop :for j :below end-j
               :do (loop :for i :from (+ start-i j) :below m

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -45,6 +45,9 @@
            #:time-backends
            #:define-extensible-function ; For extensions, not users...
 
+           #:allocate-storage
+           #:*default-allocator*
+
            ;; abstract-tensor protocol
            #:abstract-tensor
            #:specialize-tensor

--- a/tests/allocation-tests.lisp
+++ b/tests/allocation-tests.lisp
@@ -1,0 +1,33 @@
+;;; allocation-tests.lisp
+;;;
+;;; Author: Erik Davis
+
+(in-package #:magicl-tests)
+
+(defstruct alloc-counts
+  (calls 0)
+  (finals 0))
+
+
+(deftest test-custom-allocation ()
+  (let ((calls 0)
+        (finals 0))
+    (flet ((alloc (size &key element-type initial-element)
+             (declare (ignore initial-element))
+             (let ((storage
+                     (make-array size :element-type element-type)))
+               (incf calls)
+               (values storage
+                       (lambda ()
+                         (incf finals))))))
+      (let ((magicl::*default-allocator* #'alloc))      
+        (let ((m1 (magicl:zeros '(2)))
+              (m2 (magicl:zeros '(2 3)))
+              (m3 (magicl:zeros '(2 3 4))))
+          (magicl:copy-tensor m1)
+          (magicl:copy-tensor m2)
+          (magicl:copy-tensor m3)
+          nil)))
+    (tg:gc :full t)
+    ;; no good way to actually force finalization, so we don't test it
+    (is (= 6 calls))))

--- a/tests/high-level-tests.lisp
+++ b/tests/high-level-tests.lisp
@@ -95,7 +95,7 @@
                       (values matrix))
              (let* ((m (magicl:nrows diag))
                     (k (magicl:ncols matrix))
-                    (result (magicl:empty (list m k))))
+                    (result (magicl:zeros (list m k))))
                (dotimes (i (min m (magicl:ncols diag)) result)
                  (let ((dii (magicl:tref diag i i)))
                    (dotimes (j k)


### PR DESCRIPTION
It'd be nice if we had a bit more control over where tensor storage comes from, so this adds that. My main interest is in using this with `static-vectors`, but we could also consider other options (e.g. posix shared memory, as in the QVM).