### PR TITLE
Add LINEAR-SOLVE

### DIFF
--- a/src/extensions/lapack/lapack-bindings.lisp
+++ b/src/extensions/lapack/lapack-bindings.lisp
@@ -26,6 +26,8 @@
                               (blas-routine "gemm") (blas-routine "gemv"))
                              (generate-lapack-lu-for-type
                               matrix-class type (lapack-routine "getrf"))
+                             (generate-lapack-lu-solve-for-type
+                              matrix-class type (lapack-routine "getrs"))
                              (generate-lapack-inv-for-type
                               matrix-class type
                               (lapack-routine "getrf") (lapack-routine "getri"))

--- a/src/extensions/lapack/lapack-generics.lisp
+++ b/src/extensions/lapack/lapack-generics.lisp
@@ -15,6 +15,8 @@
 
 (magicl:define-extensible-function (magicl:lu lapack-lu :lapack) (matrix))
 
+(magicl:define-extensible-function (magicl:lu-solve lapack-lu-solve :lapack) (lu ipiv b))
+
 (magicl:define-extensible-function (magicl:inv lapack-inv :lapack) (matrix))
 
 (magicl:define-extensible-function (magicl:csd csd-extension :lapack) (matrix p q))

--- a/src/high-level/constructors.lisp
+++ b/src/high-level/constructors.lisp
@@ -157,6 +157,22 @@ The tensor is specialized on SHAPE and TYPE."
           (tg:finalize tensor finalizer)
           tensor)))))
 
+(defun from-storage (storage shape &key layout)
+  "Create a tensor with the specified STORAGE and SHAPE.
+
+This shares STORAGE; mutate at your own peril!
+
+LAYOUT specifies the internal storage representation ordering of the returned tensor."
+  (policy-cond:with-expectations (> speed safety)
+      ((type shape shape)
+       (assertion (cl:= 1 (array-rank storage)))
+       (assertion (cl:= (reduce #'* shape)
+                        (array-total-size storage))))
+    (let* ((tensor-type (infer-tensor-type (array-element-type storage) shape nil))
+           (tensor (make-tensor tensor-type shape :layout layout)))
+      (setf (storage tensor) storage)
+      tensor)))
+
 (defun from-list (list shape &key type layout (input-layout :row-major))
   "Create a tensor with the elements of LIST, placing in layout INPUT-LAYOUT
 

--- a/src/high-level/tensor.lisp
+++ b/src/high-level/tensor.lisp
@@ -51,6 +51,9 @@ COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
        (defmethod storage ((m ,name))
          (,storage-sym m))
 
+       (defmethod (setf storage) (new-value (m ,name))
+         (setf (,storage-sym m) new-value))
+
        (defmethod element-type ((m ,name))
          (declare (ignore m))
          ',type)

--- a/src/high-level/vector.lisp
+++ b/src/high-level/vector.lisp
@@ -38,6 +38,9 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
        (defmethod storage ((v ,name))
          (,storage-sym v))
 
+       (defmethod (setf storage) (new-value (v ,name))
+         (setf (,storage-sym v) new-value))
+
        (defmethod element-type ((v ,name))
          (declare (ignore v))
          ',type)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -161,6 +161,7 @@
            #:hermitian-eig
            #:inv
            #:lu
+           #:lu-solve
            #:csd
            #:svd
            #:ql
@@ -170,6 +171,7 @@
            #:expm
            #:logm
            #:expih
+           #:linear-solve
 
            #:polynomial
            #:make-polynomial

--- a/tests/high-level-tests.lisp
+++ b/tests/high-level-tests.lisp
@@ -233,3 +233,13 @@
           (funcall factorization fat)
         (is (magicl:= (magicl:@ a b) fat)))
       (signals error (funcall factorization tall)))))
+
+(deftest test-linear-solve ()
+  "Check that we can solve a linear system."
+  (let ((A (magicl:from-list '(0d0 1d0 1d0 2d0) '(2 2)))
+        (b (magicl:from-list '(1d0 1d0) '(2))))
+    (let ((x (magicl:linear-solve A b)))
+      (is (magicl:= b (magicl:@ A x)))))
+
+  (signals magicl::rank-deficiency-error
+    (magicl:linear-solve (magicl:ones '(3 3)) (magicl:ones '(3)))))


### PR DESCRIPTION
This adds a `linear-solve` routine for Ax=b. Right now it only supports full-rank matrices via LU-factorization, although in  the future we could add more cases. This is faster and safer than multiplying by `(inv A)`.