### PR TITLE
magicl.asd: APPLY-OUTPUT-TRANSLATIONS on Fortran outputs

### DIFF
--- a/magicl.asd
+++ b/magicl.asd
@@ -139,10 +139,12 @@
 (defmethod perform ((operation compile-op) (component f->so))
   (flet ((nn (x) (uiop:native-namestring x)))
     (let* ((fortran-file (component-pathname component))
-           (object-file (make-pathname :type "o" :defaults fortran-file))
+           (object-file (apply-output-translations
+       		         (make-pathname :type "o" :defaults fortran-file)))
            (shared-object (make-pathname :type #+darwin "dylib" #-darwin "so"
                                          :name "libexpokit"
-                                         :defaults fortran-file)))
+                                         :defaults object-file)))
+      (ensure-directories-exist shared-object)
       (uiop:run-program
        (list "gfortran" "-fPIC" "-std=legacy"
              "-c"


### PR DESCRIPTION
Call `ASDF/OUTPUT-TRANSLATIONS:APPLY-OUTPUT-TRANSLATIONS` on Fortran output objects so that they are treated consistently with Lisp objects, e.g. written into $HOME/.cache/common-lisp/... instead of inline in the source tree.

(This resolves a problem I have adding Magicl to a Nix-based environment that stores sources on a read-only filesystem: Magicl would try to compile the Fortran code there in place and fail.)

Note: This commit is based on the latest release in Quicklisp, v0.9.1.