### PR TITLE
Add methods to magicl:=-lisp so that magicl:= will compare scalars.

### DIFF
--- a/src/high-level/types/double-float.lisp
+++ b/src/high-level/types/double-float.lisp
@@ -22,6 +22,15 @@
   matrix/double-float
   vector/double-float)
 
+(defmethod =-lisp ((scalar1 double-float) (scalar2 double-float) &optional (epsilon *double-comparison-threshold*))
+  (%scalar= scalar1 scalar2 epsilon))
+
+(defmethod =-lisp ((scalar1 rational) (scalar2 double-float) &optional (epsilon *double-comparison-threshold*))
+ (%scalar= scalar1 scalar2 epsilon))
+
+(defmethod =-lisp ((scalar1 double-float) (scalar2 rational) &optional (epsilon *double-comparison-threshold*))
+  (%scalar= scalar1 scalar2 epsilon))
+
 (defmethod =-lisp ((tensor1 tensor/double-float) (tensor2 tensor/double-float) &optional (epsilon *double-comparison-threshold*))
   (unless (equal (shape tensor1) (shape tensor2))
     (return-from =-lisp nil))

--- a/src/high-level/types/single-float.lisp
+++ b/src/high-level/types/single-float.lisp
@@ -22,6 +22,37 @@
   matrix/single-float
   vector/single-float)
 
+;; Might want to inline this
+(defun %scalar= (s1 s2 epsilon)
+  "For equality checks of inexact scalars."
+  (declare (type number s1 s2) ; you can use this on complex but it might be slower because of the sqrt and two multiplies. Maybe.
+           (type real epsilon))
+  (<= (abs (- s1
+              s2))
+      epsilon))
+
+(defmethod =-lisp ((scalar1 rational) (scalar2 rational) &optional epsilon)
+  (declare (ignore epsilon))
+   "Rationals (integers and ratios) should be compared exactly."
+  (common-lisp:= scalar1 scalar2))
+
+(defmethod =-lisp ((scalar1 single-float) (scalar2 single-float) &optional (epsilon *float-comparison-threshold*))
+  (%scalar= scalar1 scalar2 epsilon))
+
+(defmethod =-lisp ((scalar1 rational) (scalar2 single-float) &optional (epsilon *float-comparison-threshold*))
+  (%scalar= scalar1 scalar2 epsilon))
+
+(defmethod =-lisp ((scalar1 single-float) (scalar2 rational) &optional (epsilon *float-comparison-threshold*))
+  (%scalar= scalar1 scalar2 epsilon))
+
+(defmethod =-lisp ((scalar1 float) (scalar2 single-float) &optional (epsilon *float-comparison-threshold*))
+  "This covers comparing double-float to single-float. Use least precise epsilon."
+  (%scalar= scalar1 scalar2 epsilon))
+
+(defmethod =-lisp ((scalar1 single-float) (scalar2 float) &optional (epsilon *float-comparison-threshold*))
+  "This covers comparing single-float to double-float. Use least precise epsilon."
+  (%scalar= scalar1 scalar2 epsilon))
+
 (defmethod =-lisp ((tensor1 tensor/single-float) (tensor2 tensor/single-float) &optional (epsilon *float-comparison-threshold*))
   (unless (equal (shape tensor1) (shape tensor2))
     (return-from =-lisp nil))

--- a/tests/high-level-tests.lisp
+++ b/tests/high-level-tests.lisp
@@ -11,24 +11,24 @@
   (let* ((x (magicl:from-list '(6 4 2 1 -2 8 1 5 7) '(3 3)
                               :type 'double-float))
          (d (magicl:det x)))
-    (is (= d -306d0))))
+    (is (magicl:= d -306d0))))
 
 (deftest test-p-norm ()
   "Test that the p-norm of vectors returns sane values."
   ;; Basic 3-4-5
-  (is (= 5 (magicl:norm (magicl:from-list '(3 4) '(2)))))
+  (is (magicl:= 5 (magicl:norm (magicl:from-list '(3 4) '(2)))))
   ;; One element vector should return element for all
   (loop :for val :in '(-3 0 10) :do
     (let ((x (magicl:from-list (list val) '(1))))
-      (is (= (abs val) (magicl:norm x 1)))
-      (is (= (abs val) (magicl:norm x 2)))
-      (is (= (abs val) (magicl:norm x 3)))
-      (is (= (abs val) (magicl:norm x :infinity)))))
+      (is (magicl:= (abs val) (magicl:norm x 1)))
+      (is (magicl:= (abs val) (magicl:norm x 2)))
+      (is (magicl:= (abs val) (magicl:norm x 3)))
+      (is (magicl:= (abs val) (magicl:norm x :infinity)))))
   ;; Test known values
   (let ((x (magicl:from-list '(1 -2 3 4 5 -6) '(6))))
-    (is (= 6 (magicl:norm x :infinity)))
-    (is (= 21 (magicl:norm x 1)))
-    (is (= 9.539392 (magicl:norm x 2)))))
+    (is (magicl:= 6 (magicl:norm x :infinity)))
+    (is (magicl:= 21 (magicl:norm x 1)))
+    (is (magicl:= 9.539392 (magicl:norm x 2)))))
 
 (deftest test-examples ()
   "Run all of the examples. Does not check for their correctness."


### PR DESCRIPTION
Add #'test-scalar-equality to test those methods.
Modify #'test-p-norm to use magicl:= rather than common-lisp:= because
it's (potentially) comparing floats.