### PR TITLE
Resolves #156: Cannot load fortran lib

### DIFF
--- a/src/extensions/expokit/load-libs.lisp
+++ b/src/extensions/expokit/load-libs.lisp
@@ -5,22 +5,28 @@
 (in-package #:magicl.foreign-libraries)
 
 (cffi:define-foreign-library libexpokit
-  (:darwin (:or #.(asdf:system-relative-pathname '#:magicl "expokit/libexpokit.dylib")
-                "libexpokit.dylib"
-                "expokit.dylib"))
-  (:unix  (:or #.(asdf:system-relative-pathname '#:magicl "expokit/libexpokit.so")
-               "libexpokit.so"
-               "expokit.so"))
+  (:darwin (:or "libexpokit.dylib" "expokit.dylib"))
+  (:unix  (:or "libexpokit.so" "expokit.so"))
   (t (:default "expokit")))
 
 (pushnew 'libexpokit *foreign-libraries*)
+
+
+(pushnew (asdf:apply-output-translations "expokit/")
+         cffi:*foreign-library-directories*
+         :test #'equal)
+
+;; Keep above in sync with 'perform ((... compile-op) (... f->so))'
+;; method in magicl.asd.
+
+
 (export 'libexpokit)
 
 (defvar *expokit-libs-loaded* nil)
 
 (unless *expokit-libs-loaded*
   (cffi:load-foreign-library 'libexpokit)
-  (setf *expokit-libs-loaded* nil))
+  (setf *expokit-libs-loaded* t))
 
 (magicl:define-backend :expokit
   :documentation "Functions available from Expokit."


### PR DESCRIPTION
File changed: src/extensions/expokit/load-libs.lisp

This changes fortran library loading to correspond with the recent
changes in magicl.asd that changed the directory location of the
LIBEXPOKIT fortran library.

Previously, the loading code defined the library to exist in a
directory relative to the source tree, and now it defines that
directory relative to the output tree, i.e., where we output fasls,
etc., as per the recent change in magicl.asd.

We now use cffi:*foreign-library-directories* to define the location
instead of sticking read-time-evaluated pathnames into the library
definition. It's less code, since it does not need to branch per
platform (cf. old darwin/linux cases). It also should work on Windows
besides macOS and Linux, though that hasn't been tested. It also is
better in that the location setting is done at load time, whereas the
old approach did it at read time (not really the right time).

Along the way, noticed and fixed a minor problem:
*expokit-libs-loaded* was not being set to true after loading.