### PR TITLE
Make magicl compatible with LispWorks 8

### DIFF
--- a/src/extensions/blas/package.lisp
+++ b/src/extensions/blas/package.lisp
@@ -12,4 +12,5 @@
                           #:every
                           #:some
                           #:notevery
-                          #:notany))
+                          #:notany
+                          #:make-array))

--- a/src/extensions/lapack/lapack-templates.lisp
+++ b/src/extensions/lapack/lapack-templates.lisp
@@ -209,7 +209,7 @@
             (jobvt (if reduced "S" "A"))
             (rows (nrows m))
             (cols (ncols m))
-            (a (alexandria:copy-array (magicl::storage (if (eql :row-major (layout m)) (transpose m) m))))
+            (a (magicl::storage (deep-copy-tensor (if (eql :row-major (layout m)) (transpose m) m))))
             (lwork -1)
             (info 0)
             (k (min rows cols))

--- a/src/extensions/lapack/package.lisp
+++ b/src/extensions/lapack/package.lisp
@@ -12,7 +12,8 @@
                           #:every
                           #:some
                           #:notevery
-                          #:notany)
+                          #:notany
+                          #:make-array)
   (:export
    #:lapack-eig
    #:lapack-lu

--- a/src/high-level/abstract-tensor.lisp
+++ b/src/high-level/abstract-tensor.lisp
@@ -309,3 +309,9 @@ If TARGET is not specified then a new tensor is created with the same element ty
               tensor
               target)
       target)))
+
+(declaim (inline make-array))
+(defun make-array (dimensions &rest args &key &allow-other-keys)
+  (apply #'cl:make-array dimensions
+         #+lispworks8 :allocation #+lispworks8 :pinnable
+         args))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -27,7 +27,8 @@
            #:every
            #:some
            #:notevery
-           #:notany)
+           #:notany
+           #:make-array)
 
   (:import-from #:magicl.backends
                 #:no-applicable-implementation
@@ -67,6 +68,7 @@
            #:some
            #:notevery
            #:notany
+           #:make-array
 
            #:map
            #:map!


### PR DESCRIPTION
These changes should make magicl work with LispWorks 8 when installed through `quicklisp/local-projects`.