### PR TITLE
Configure repo to not convert LF to CLRF on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.lisp linguist-language=Common-Lisp
+*.lisp text eol=lf


### PR DESCRIPTION
Git's default behavior is to convert LFs to CLRFs when checking out on Windows.
This breaks the tilde newline format directive as described here:
https://sourceforge.net/p/sbcl/mailman/sbcl-devel/thread/4D50C7E6.20400%40yv.org/#msg27025402

Also see
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
for details on configuring line endings in Git.

Same fix as quil-lang/quilc#798.

## Testing
Successfully built magicl on Windows.