### PR TITLE
Extend basic operations

### DIFF
--- a/doc/high-level.md
+++ b/doc/high-level.md
@@ -74,6 +74,8 @@ Magicl provides some "block matrix" constructors: these construct matrices from 
 | `(.^ a b)`   | `a.^b`     | `np.power(a,b)`   | Element-wise exponentiation    |
 | `(.exp a)`   | `exp(a)`   | `np.exp(a)`       | Element-wise exponential       |
 | `(.log a)`   | `log(a)`   | `np.log(a)`       | Element-wise natural logarithm |
+| `(.max a b)` | `max(a,b)` | `np.maximum(a,b)` | Element-wise maximum           |
+| `(.min a b)` | `min(a,b)` | `np.minimum(a,b)` | Element-wise minimum           |
 
 Note: Elementwise operators with two arguments (e.g. `.+`, `.-`) also act as expected when one argument is a number; for example `(.- A 5.0)` subtracts 5.0 from each element of A.
 

--- a/doc/high-level.md
+++ b/doc/high-level.md
@@ -75,6 +75,8 @@ Magicl provides some "block matrix" constructors: these construct matrices from 
 | `(.exp a)`   | `exp(a)`   | `np.exp(a)`       | Element-wise exponential       |
 | `(.log a)`   | `log(a)`   | `np.log(a)`       | Element-wise natural logarithm |
 
+Note: Elementwise operators with two arguments (e.g. `.+`, `.-`) also act as expected when one argument is a number; for example `(.- A 5.0)` subtracts 5.0 from each element of A.
+
 ### Linear Algebra
 
 | MAGICL                                                  | MATLAB            | NumPy                                                          | Description                                |

--- a/doc/high-level.md
+++ b/doc/high-level.md
@@ -64,14 +64,16 @@ Magicl provides some "block matrix" constructors: these construct matrices from 
 
 ### Basic Operations
 
-| MAGICL     | MATLAB   | NumPy            | Description                 |
-|------------|----------|------------------|-----------------------------|
-| `(@ a b)`  | `a * b`  | `a @ b`          | Matrix multiplication       |
-| `(.+ a b)` | `a + b`  | `a + b`          | Element-wise add            |
-| `(.- a b)` | `a - b`  | `a - b`          | Element-wise subtract       |
-| `(.* a b)` | `a .* b` | `a * b`          | Element-wise multiply       |
-| `(./ a b)` | `a./b`   | `a/b`            | Element-wise divide         |
-| `(.^ a b)` | `a.^b`   | `np.power(a,b)`  | Element-wise exponentiation |
+| MAGICL       | MATLAB     | NumPy             | Description                    |
+|--------------|------------|-------------------|--------------------------------|
+| `(@ a b)`    | `a * b`    | `a @ b`           | Matrix multiplication          |
+| `(.+ a b)`   | `a + b`    | `a + b`           | Element-wise add               |
+| `(.- a b)`   | `a - b`    | `a - b`           | Element-wise subtract          |
+| `(.* a b)`   | `a .* b`   | `a * b`           | Element-wise multiply          |
+| `(./ a b)`   | `a./b`     | `a/b`             | Element-wise divide            |
+| `(.^ a b)`   | `a.^b`     | `np.power(a,b)`   | Element-wise exponentiation    |
+| `(.exp a)`   | `exp(a)`   | `np.exp(a)`       | Element-wise exponential       |
+| `(.log a)`   | `log(a)`   | `np.log(a)`       | Element-wise natural logarithm |
 
 ### Linear Algebra
 

--- a/src/high-level/abstract-tensor.lisp
+++ b/src/high-level/abstract-tensor.lisp
@@ -279,22 +279,18 @@ If TARGET is not specified then a new tensor is created with the same element ty
     ;; choice, like integers.
     (binary-operator #'expt source1 source2 target)))
 
-(define-backend-function .max (source1 source2 &optional target)
-  "Apply MAX function to tensors elementwise, optionally storing the result in TARGET.
+(define-extensible-function (.max max-lisp) (source1 source2 &optional target)
+  (:documentation "Apply MAX function to tensors elementwise, optionally storing the result in TARGET.
 If TARGET is not specified then a new tensor is created with the same element type as the first source tensor.
 If one argument is a NUMBER then apply MAX function to tensor element and number")
-
-(define-backend-implementation .max :lisp
-  (lambda (source1 source2 &optional target)
+  (:method (source1 source2 &optional target)
     (binary-operator #'max source1 source2 target)))
 
-(define-backend-function .min (source1 source2 &optional target)
-  "Apply MIN function to tensors elementwise, optionally storing the result in TARGET.
+(define-extensible-function (.min min-lisp) (source1 source2 &optional target)
+  (:documentation "Apply MIN function to tensors elementwise, optionally storing the result in TARGET.
 If TARGET is not specified then a new tensor is created with the same element type as the first source tensor.
 If one argument is a NUMBER then apply MIN function to tensor element and number")
-
-(define-backend-implementation .min :lisp
-  (lambda (source1 source2 &optional target)
+  (:method (source1 source2 &optional target)
     (binary-operator #'min source1 source2 target)))
 
 

--- a/src/high-level/abstract-tensor.lisp
+++ b/src/high-level/abstract-tensor.lisp
@@ -246,6 +246,33 @@ If TARGET is not specified then a new tensor is created with the same element ty
     (binary-operator #'expt source1 source2 target)))
 
 
+
+(defgeneric unary-operator (function source &optional target)
+  (:documentation "Perform a unary operator on tensor elementwise, optionally storing the result in TARGET.
+If TARGET is not specified then a new tensor is created with the same element type as the source tensor")
+  (:method ((function function) (source abstract-tensor) &optional target)
+    (let ((target (or target (copy-tensor source))))
+      (map-indexes
+       (shape source)
+       (lambda (&rest dims)
+         (apply #'(setf tref)
+                (funcall function
+                         (apply #'tref source dims))
+                target dims)))
+      target)))
+
+(define-extensible-function (.exp exp-lisp) (source &optional target)
+  (:documentation "Applies exponential function to tensor elementwise, optionally storing the restult in TARGET.
+If TARGET is not specified then a new tensor is created with the same element type as the source tensor")
+  (:method ((source abstract-tensor) &optional target)
+    (unary-operator #'exp source target)))
+
+(define-extensible-function (.log log-lisp) (source &optional target)
+  (:documentation "Applies natural logarithm to tensor elementwise, optionally storing the restult in TARGET.
+If TARGET is not specified then a new tensor is created with the same element type as the source tensor")
+  (:method ((source abstract-tensor) &optional target)
+    (unary-operator #'log source target)))
+
 (define-extensible-function (= =-lisp) (source1 source2 &optional epsilon)
   (:documentation "Check the equality of tensors with an optional EPSILON")
   (:method ((source1 abstract-tensor) (source2 abstract-tensor) &optional epsilon)

--- a/src/high-level/abstract-tensor.lisp
+++ b/src/high-level/abstract-tensor.lisp
@@ -279,6 +279,23 @@ If TARGET is not specified then a new tensor is created with the same element ty
     ;; choice, like integers.
     (binary-operator #'expt source1 source2 target)))
 
+(define-backend-function .max (source1 source2 &optional target)
+  "Apply MAX function to tensors elementwise, optionally storing the result in TARGET.
+If TARGET is not specified then a new tensor is created with the same element type as the first source tensor.
+If one argument is a NUMBER then apply MAX function to tensor element and number")
+
+(define-backend-implementation .max :lisp
+  (lambda (source1 source2 &optional target)
+    (binary-operator #'max source1 source2 target)))
+
+(define-backend-function .min (source1 source2 &optional target)
+  "Apply MIN function to tensors elementwise, optionally storing the result in TARGET.
+If TARGET is not specified then a new tensor is created with the same element type as the first source tensor.
+If one argument is a NUMBER then apply MIN function to tensor element and number")
+
+(define-backend-implementation .min :lisp
+  (lambda (source1 source2 &optional target)
+    (binary-operator #'min source1 source2 target)))
 
 
 (defgeneric unary-operator (function source &optional target)
@@ -306,6 +323,7 @@ If TARGET is not specified then a new tensor is created with the same element ty
 If TARGET is not specified then a new tensor is created with the same element type as the source tensor")
   (:method ((source abstract-tensor) &optional target)
     (unary-operator #'log source target)))
+
 
 (define-extensible-function (= =-lisp) (source1 source2 &optional epsilon)
   (:documentation "Check the equality of tensors with an optional EPSILON")

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -123,6 +123,7 @@
 
            ;; Operators
            #:binary-operator
+           #:unary-operator
            #:.+
            #:.-
            #:.*
@@ -130,6 +131,8 @@
            #:.^
            #:=
            #:map
+           #:.exp
+           #:.log
 
            ;; Matrix operators
            #:square-matrix-p

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -133,6 +133,8 @@
            #:map
            #:.exp
            #:.log
+           #:.max
+           #:.min
 
            ;; Matrix operators
            #:square-matrix-p

--- a/tests/abstract-tensor-tests.lisp
+++ b/tests/abstract-tensor-tests.lisp
@@ -32,3 +32,68 @@
                                   :type 'double-float)))
     (loop :for i :below 15
           :do (= i (apply #'magicl:tref tensor (magicl::from-row-major-index i '(3 5)))))))
+
+(deftest test-tensor-number-ops ()
+  "Test that basic operations on a tensor and number give the expected results"
+  (let* ((input '(-1.0 -0.5 0.5 1.0))
+         (tensor (magicl:from-list input
+                                   '(2 2)
+                                   :type 'single-float)))
+
+    ;; .+
+    (is (magicl:= (magicl:.+ tensor 3.14)
+                  (magicl:from-list (loop for i in input collect (+ i 3.14))
+                                    (magicl:shape tensor)
+                                    :type 'single-float)))
+
+    ;; .-
+    (is (magicl:= (magicl:.- 3.14 tensor)
+                  (magicl:from-list (loop for i in input collect (- 3.14 i))
+                                    (magicl:shape tensor)
+                                    :type 'single-float)))
+
+    ;; .*
+    (is (magicl:= (magicl:.* 3.14 tensor)
+                  (magicl:from-list (loop for i in input collect (* 3.14 i))
+                                    (magicl:shape tensor)
+                                    :type 'single-float)))
+
+    ;; ./
+    (is (magicl:= (magicl:./ 3.14 tensor)
+                  (magicl:from-list (loop for i in input collect (/ 3.14 i))
+                                    (magicl:shape tensor)
+                                    :type 'single-float)))
+
+    ;; .max
+    (is (magicl:= (magicl:.max tensor 0.0)
+                  (magicl:from-list (loop for i in input collect (max 0.0 i))
+                                    (magicl:shape tensor)
+                                    :type 'single-float)))
+    ;; .min
+    (is (magicl:= (magicl:.min 0.0 tensor)
+                  (magicl:from-list (loop for i in input collect (min i 0.0))
+                                    (magicl:shape tensor)
+                                    :type 'single-float)))))
+
+(deftest test-unary-ops ()
+  "Test that basic unary operations on a tensor give the expected results"
+  (let* ((input '(-1.1 -0.4 0.5 1.0))
+         (tensor (magicl:from-list input
+                                   '(2 2)
+                                   :type 'single-float)))
+
+    ;; .exp
+    (is (magicl:= (magicl:.exp tensor)
+                  (magicl:from-list (loop for i in input collect (exp i))
+                                    (magicl:shape tensor)
+                                    :type 'single-float)))
+
+    ;; .log - Recall natural log of negative numbers are undefined!
+    (let* ((input '(0.1 0.5 1.1 2.0))
+           (tensor (magicl:from-list input
+                                     '(2 2)
+                                     :type 'single-float)))
+      (is (magicl:= (magicl:.log tensor)
+                    (magicl:from-list (loop for i in input collect (log i))
+                                      (magicl:shape tensor)
+                                      :type 'single-float))))))


### PR DESCRIPTION
Extend basic basic operations (i.e. elementwise ops) in three ways:

1. Allowing for a `number` instead of an `abstract-tensor` type as one of the arguments
   - This means something like `(.+ A 10)` behaves as it reads - i.e. add 10 to each element of `A`.  An alternative would have been to create a tensor the same type/shape as `A` and set all elements to 10...and then...add to `A`
2. Add an elementwise `.max` and `.min`
   - It might just be my use-case, but this means creating a [ReLU](https://en.wikipedia.org/wiki/Rectifier_(neural_networks)) function is then as simple as `(.max 0.0 A)`
3. Add elementwise `.exp` and `.log` (natural log)
   - These need a `unary-operator` function, which will look suspiciously like the existing `binary-operator`, but with only one argument


### Additional thoughts
1. There are no tests.  Happy to write them if requested.
2. The `.max` and `.min` functions suffer from the existing issue that if the type of the arguments differ then we can get a TYPE-ERROR from the SETF.  See [issue #173](https://github.com/quil-lang/magicl/issues/173).  So rather than `(.max A 0)`, it's better to be explicit and write `(.max A 0.0)`.
