### PR TITLE
add homebrew path for shared libraries

### DIFF
--- a/src/extensions/blas/load-libs.lisp
+++ b/src/extensions/blas/load-libs.lisp
@@ -4,7 +4,10 @@
   #+:magicl.use-accelerate
   (:darwin "libBLAS.dylib" :search-path #P"/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/A/")
   #-:magicl.use-accelerate
-  (:darwin (:or "/usr/local/opt/lapack/lib/libblas.dylib" "libblas.dylib" ))
+  (:darwin (:or
+            "/opt/homebrew/opt/lapack/lib/libblas.dylib"
+            "/usr/local/opt/lapack/lib/libblas.dylib"
+            "libblas.dylib" ))
   #+:magicl.use-mkl
   (:unix  "libmkl_rt.so")
   #-:magicl.use-mkl

--- a/src/extensions/lapack/load-libs.lisp
+++ b/src/extensions/lapack/load-libs.lisp
@@ -8,7 +8,10 @@
   ;; because it's more complete. (macOS-provided LAPACK doesn't have a
   ;; lot of the more obscure subroutines.)
   #-:magicl.use-accelerate
-  (:darwin (:or "/usr/local/opt/lapack/lib/liblapack.dylib" "liblapack.dylib"))
+  (:darwin (:or
+            "/opt/homebrew/opt/lapack/lib/liblapack.dylib"
+            "/usr/local/opt/lapack/lib/liblapack.dylib"
+            "liblapack.dylib"))
   #+:magicl.use-mkl
   (:unix  "libmkl_rt.so")
   #-:magicl.use-mkl


### PR DESCRIPTION
homebrew on macOS on ARM defaults to a different directory than previously on x86