### PR TITLE
Bug fix, specified type.

### DIFF
--- a/src/high-level/constructors.lisp
+++ b/src/high-level/constructors.lisp
@@ -144,12 +144,12 @@ The tensor is specialized on SHAPE and TYPE."
               shape
               (lambda (&rest pos)
                 (setf (aref storage (funcall index-function pos shape))
-                      (aref array (funcall input-index-function pos shape))))))
+                      (coerce (aref array (funcall input-index-function pos shape)) type)))))
             (t (map-indexes
                 shape
                 (lambda (&rest pos)
                   (setf (aref storage (funcall index-function pos shape))
-                        (apply #'aref array pos)))))))
+                        (coerce (apply #'aref array pos) type)))))))
         (let ((tensor
                 (make-tensor tensor-class shape
                              :storage storage

--- a/src/high-level/matrix-functions/eig/eig.lisp
+++ b/src/high-level/matrix-functions/eig/eig.lisp
@@ -38,7 +38,7 @@
          (right-vecs (make-array (* n n) :element-type 'double-float :initial-element 0.0d0))
          (lwork      (* 4 n n))
          (work       (make-array lwork :element-type 'double-float :initial-element 0.0d0)))
-    (lapack::dgeev
+    (magicl.lapack-cffi:%dgeev          ;lapack::dgeev
      "N"                                ; left eigenvectors
      "V"                                ; right eigenvectors
      n                                  ; order
@@ -62,7 +62,7 @@
     (cond
       ((and a-real? b-real?)
        (< (realpart a) (realpart b)))
-      ((and a-real? (not b-real))
+      ((and a-real? (not b-real?))
        t)
       ((and (not a-real?) b-real?)
        nil)

--- a/src/high-level/tensor.lisp
+++ b/src/high-level/tensor.lisp
@@ -114,7 +114,7 @@ COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
                           (:row-major (row-major-index pos (tensor-shape tensor)))
                           (:column-major (column-major-index pos (tensor-shape tensor))))))
              (setf (aref (,storage-sym tensor) index)
-                   new-value)))))))
+                   (coerce new-value ',type))))))))
 
 (defun pprint-tensor (stream tensor &optional colon-p at-sign-p)
   "Pretty-print a matrix MATRIX to the stream STREAM."

--- a/src/high-level/vector.lisp
+++ b/src/high-level/vector.lisp
@@ -108,7 +108,8 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
        (defmethod (setf tref) (new-value (vector ,name) &rest pos)
          (policy-cond:with-expectations (> speed safety)
              ((assertion (valid-index-p pos (list (vector-size vector)))))
-           (setf (aref (,storage-sym vector) (first pos)) new-value))))))
+           (setf (aref (,storage-sym vector) (first pos))
+				 (coerce new-value ',type)))))))
 
 
 (defun pprint-vector (stream vector)

--- a/src/high-level/vector.lisp
+++ b/src/high-level/vector.lisp
@@ -109,7 +109,7 @@ ELEMENT-TYPE, CAST, COPY-TENSOR, DEEP-COPY-TENSOR, TREF, SETF TREF)"
          (policy-cond:with-expectations (> speed safety)
              ((assertion (valid-index-p pos (list (vector-size vector)))))
            (setf (aref (,storage-sym vector) (first pos))
-				 (coerce new-value ',type)))))))
+           	 (coerce new-value ',type)))))))
 
 
 (defun pprint-vector (stream vector)

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -153,7 +153,7 @@
            #:kron
            #:scale
            #:scale!
-	   #:sum
+           #:sum
            #:diag
            #:det
            #:upper-triangular

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -153,6 +153,7 @@
            #:kron
            #:scale
            #:scale!
+		   #:sum
            #:diag
            #:det
            #:upper-triangular

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -153,7 +153,7 @@
            #:kron
            #:scale
            #:scale!
-		   #:sum
+	   #:sum
            #:diag
            #:det
            #:upper-triangular


### PR DESCRIPTION
Hi,
when I specified type for vector and tensor, error:


MAGICL> (from-list  '(1 2 3 4 5 6) '(6) :type 'double-float)

The value
  1
is not of type
  DOUBLE-FLOAT
when setting an element of (ARRAY DOUBLE-FLOAT)
   [Condition of type TYPE-ERROR]



after fix:

MAGICL> (from-list '(1 2 3 4 5 6) '(6) :type 'double-float)
#<VECTOR/DOUBLE-FLOAT (6):
   1.000
   2.000
   3.000
   4.000
   5.000
   6.000>

best wishes!
