### PR TITLE
fix matrix stacking test

### DIFF
--- a/tests/matrix-tests.lisp
+++ b/tests/matrix-tests.lisp
@@ -183,11 +183,11 @@
     (is (magicl:= expected
                   (magicl:hstack
                    (loop :for j :below 3
-                         :collect (magicl:column expected j)))))
+                         :collect (magicl:vector->column-matrix (magicl:column expected j))))))
     (is (magicl:= expected
                   (magicl:vstack
                    (loop :for i :below 2
-                         :collect (magicl:row expected i)))))))
+                         :collect (magicl:vector->row-matrix (magicl:row expected i))))))))
 
 
 (deftest test-block-matrix-construction ()


### PR DESCRIPTION
07edc0f changed the return type of `magicl:row` and `magicl:column`, causing `test-matrix-stacking` to fail.

This was also mentioned in issue #203.