### PR TITLE
Fix compiler warnings when loading `magicl`

### DIFF
--- a/doc/dev-how-to.md
+++ b/doc/dev-how-to.md
@@ -33,12 +33,11 @@ Let's say we want to add a fused multiply-add function called
 
 This defines `fma` as the main API function, and `fma-lisp` as the
 generic function implementing `fma`. If we want to implement `fma` in
-a specific backend, we can use the same form, but adding the backend's
-name as an option. For example, if we are implementing this function
-with BLAS acceleration, we can specify the `:blas` backend:
+a specific backend, we can use `extend-function` to extend `fma` into the backend. For example, if we are extending this function
+with BLAS acceleration, we can specify the `:blas` backend and write,
 
 ```
-(define-extensible-function (fma fma-blas :blas) (a x b)
+(extend-function (fma fma-blas :blas) (a x b)
   (:method (a x b)
     (some-funny-blas-function a x b)))
 ```
@@ -198,16 +197,19 @@ specify two names. The above code makes the `matmul` backend function
 as implemented by the `matmul-lisp` generic function.
 
 Later on, when implementing the BLAS accelerated `matmul`, we can use
-`define-extensible-function` and specify the backend we're defining it
-for.
+`extend-function` and specify the backend we're extending it
+with.
 
 ```
 ;; in BLAS extension
-(define-extensible-function (matmul matmul-blas :blas) (a b)
+(extend-function (matmul matmul-blas :blas) (a b)
   (:method (a b)
     ;; ...
     ))
 ```
+
+As the names imply, `define-extensible-function` defines a backend function and extends it,
+and `extend-function` extends an already-defined backend function.
 
 In general, we suggest always having a pure Lisp version if feasible.
 

--- a/src/extensions/blas/arithmetic.lisp
+++ b/src/extensions/blas/arithmetic.lisp
@@ -3,8 +3,7 @@
 ;;;; Author: Vasily Postnicov
 
 (in-package #:magicl.blas)
-
-(define-extensible-function (scale! scale!-blas :blas) (tensor factor))
+(extend-function (scale! scale!-blas :blas) (tensor factor))
 
 ;; Scalar - matrix multiplication
 (macrolet ((def-scale (matrix-type scalar-type function)
@@ -68,10 +67,10 @@ DEEP-COPY-TENSOR."))
   (def-copier vector/single-float single-float)
   (def-copier vector/double-float double-float))
 
-(define-extensible-function (.+ .+-blas :blas) (source1 source2 &optional target))
-(define-extensible-function (.- .--blas :blas) (source1 source2 &optional target))
-(define-extensible-function (.* .*-blas :blas) (source1 source2 &optional target))
-(define-extensible-function (./ ./-blas :blas) (source1 source2 &optional target))
+(extend-function (.+ .+-blas :blas) (source1 source2 &optional target))
+(extend-function (.- .--blas :blas) (source1 source2 &optional target))
+(extend-function (.* .*-blas :blas) (source1 source2 &optional target))
+(extend-function (./ ./-blas :blas) (source1 source2 &optional target))
 
 ;; Fast matrix/vector addition
 (macrolet ((def-+ (tensor-type scalar-type function)

--- a/src/extensions/lapack/lapack-generics.lisp
+++ b/src/extensions/lapack/lapack-generics.lisp
@@ -7,33 +7,33 @@
 ;;; We use the convention "FOO-EXTENSION" to refer to this extension's
 ;;; generic function implementation of MAGICL:FOO.
 
-(magicl:define-extensible-function (magicl:mult mult-extension :lapack) (a b &key target alpha beta transa transb))
+(magicl:extend-function (magicl:mult mult-extension :lapack) (a b &key target alpha beta transa transb))
 
-(magicl:define-extensible-function (magicl:eig lapack-eig :lapack) (matrix))
+(magicl:extend-function (magicl:eig lapack-eig :lapack) (matrix))
 
-(magicl:define-extensible-function (magicl:hermitian-eig lapack-hermitian-eig :lapack) (matrix))
+(magicl:extend-function (magicl:hermitian-eig lapack-hermitian-eig :lapack) (matrix))
 
-(magicl:define-extensible-function (magicl:lu lapack-lu :lapack) (matrix))
+(magicl:extend-function (magicl:lu lapack-lu :lapack) (matrix))
 
-(magicl:define-extensible-function (magicl:lu-solve lapack-lu-solve :lapack) (lu ipiv b))
+(magicl:extend-function (magicl:lu-solve lapack-lu-solve :lapack) (lu ipiv b))
 
-(magicl:define-extensible-function (magicl:inv lapack-inv :lapack) (matrix))
+(magicl:extend-function (magicl:inv lapack-inv :lapack) (matrix))
 
-(magicl:define-extensible-function (magicl:csd-blocks csd-blocks-extension :lapack) (matrix p q))
+(magicl:extend-function (magicl:csd-blocks csd-blocks-extension :lapack) (matrix p q))
 
-(magicl:define-extensible-function (magicl:svd lapack-svd :lapack) (matrix &key reduced))
+(magicl:extend-function (magicl:svd lapack-svd :lapack) (matrix &key reduced))
 
-(magicl:define-extensible-function (magicl:schur schur-extension :lapack) (matrix))
+(magicl:extend-function (magicl:schur schur-extension :lapack) (matrix))
 
-(magicl:define-extensible-function (magicl:qz qz-extension :lapack) (matrix1 matrix2))
+(magicl:extend-function (magicl:qz qz-extension :lapack) (matrix1 matrix2))
 
-(magicl:define-extensible-function (magicl:ql ql-extension :lapack) (matrix))
+(magicl:extend-function (magicl:ql ql-extension :lapack) (matrix))
 
-(magicl:define-extensible-function (magicl:qr qr-extension :lapack) (matrix))
+(magicl:extend-function (magicl:qr qr-extension :lapack) (matrix))
 
-(magicl:define-extensible-function (magicl:rq rq-extension :lapack) (matrix))
+(magicl:extend-function (magicl:rq rq-extension :lapack) (matrix))
 
-(magicl:define-extensible-function (magicl:lq lq-extension :lapack) (matrix))
+(magicl:extend-function (magicl:lq lq-extension :lapack) (matrix))
 
 (defgeneric lapack-ql (matrix)
   (:documentation "Find the LAPACK intermediate representation of ql of a matrix"))

--- a/src/high-level/matrix-functions/svd.lisp
+++ b/src/high-level/matrix-functions/svd.lisp
@@ -51,7 +51,7 @@
         (declare (ignore r))
         q))))
 
-(defun svd-lisp (matrix &key reduced)
+(defmethod svd-lisp (matrix &key reduced)
   ;; short and fat => find svd of tranpose
   (when (> (ncols matrix) (nrows matrix))
     (multiple-value-bind (U D Vh) (svd-lisp (transpose matrix) :reduced reduced)

--- a/src/high-level/util.lisp
+++ b/src/high-level/util.lisp
@@ -114,9 +114,9 @@
        (define-compatible-no-applicable-method-behavior ,fun-name-backend)
        (define-backend-implementation ,fun-name ,backend ',fun-name-backend))))
 
-(defmacro extend-function ((fun-name fun-name-backend &optional (backend :lisp)) lambda-list)
+(defmacro extend-function ((fun-name fun-name-backend &optional (backend :lisp)) lambda-list &body options)
   "This macro mimics DEFGENERIC, using FUN-NAME as the backend function whose BACKEND implementation (default :LISP) is a generic function named FUN-NAME-BACKEND."
   `(progn
-       (defgeneric ,fun-name-backend ,lambda-list)
+       (defgeneric ,fun-name-backend ,lambda-list ,@options)
        (define-compatible-no-applicable-method-behavior ,fun-name-backend)
        (define-backend-implementation ,fun-name ,backend ',fun-name-backend)))

--- a/src/high-level/util.lisp
+++ b/src/high-level/util.lisp
@@ -113,3 +113,10 @@
        (defgeneric ,fun-name-backend ,lambda-list ,@options)
        (define-compatible-no-applicable-method-behavior ,fun-name-backend)
        (define-backend-implementation ,fun-name ,backend ',fun-name-backend))))
+
+(defmacro extend-function ((fun-name fun-name-backend &optional (backend :lisp)) lambda-list)
+  "This macro mimics DEFGENERIC, using FUN-NAME as the backend function whose BACKEND implementation (default :LISP) is a generic function named FUN-NAME-BACKEND."
+  `(progn
+       (defgeneric ,fun-name-backend ,lambda-list)
+       (define-compatible-no-applicable-method-behavior ,fun-name-backend)
+       (define-backend-implementation ,fun-name ,backend ',fun-name-backend)))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -44,6 +44,7 @@
   (:export #:with-blapack
            #:time-backends
            #:define-extensible-function ; For extensions, not users...
+           #:extend-function ; For extensions, not users...
 
            #:allocate-storage
            #:*default-allocator*


### PR DESCRIPTION
Addresses https://github.com/quil-lang/magicl/issues/209 and related compiler warnings.